### PR TITLE
Made lambda function name optional

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.7
 
 RUN apt-get update
 RUN apt-get install -y jq zip

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Stored as secrets or env vars, doesn't matter. But also please don't put your AW
     - Function name - `my-function`  
     - Function ARN - `arn:aws:lambda:us-west-2:123456789012:function:my-function`  
     - Partial ARN - `123456789012:function:my-function`
-    When function name is not specified, a layer is created containing contents of the lambda directory (if specified, else current working directory) and the requirements.
+ 
+ When function name is not specified, a layer is created containing contents of the lambda directory (if specified, else current working directory) and the requirements.
     
 - `lambda_directory`
     The directory with the lambda code

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Stored as secrets or env vars, doesn't matter. But also please don't put your AW
     - Function ARN - `arn:aws:lambda:us-west-2:123456789012:function:my-function`  
     - Partial ARN - `123456789012:function:my-function`
  
- When function name is not specified, a layer is created containing contents of the lambda directory (if specified, else current working directory) and the requirements.
+    When function name is not specified, a layer is created containing contents of the lambda directory (if specified, else current working directory) and the requirements.
     
 - `lambda_directory`
     The directory with the lambda code

--- a/README.md
+++ b/README.md
@@ -29,10 +29,15 @@ Stored as secrets or env vars, doesn't matter. But also please don't put your AW
     - Function name - `my-function`  
     - Function ARN - `arn:aws:lambda:us-west-2:123456789012:function:my-function`  
     - Partial ARN - `123456789012:function:my-function`
+    When function name is not specified, a layer is created containing contents of the lambda directory (if specified, else current working directory) and the requirements.
+    
 - `lambda_directory`
     The directory with the lambda code
 - `requirements_txt`
     The name/path for the `requirements.txt` file. Defaults to `requirements.txt`.
+
+### Workflow diagram
+![Workflow diagram](https://github.com/qxf2/py-lambda-action/blob/1a2217d0fccf126183f927fa0ddd1573c60a564d/py-lambda-action_workflow.png)
 
 __Implementation__
 1. I added a `lambda_directory` input argument to `action.yml`. 

--- a/action.yml
+++ b/action.yml
@@ -15,15 +15,10 @@ inputs:
     required: true
   lambda_function_name:
     description: The Lambda function name. Check the AWS docs/readme for examples.
-    required: true
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
-  args:
-    - ${{ inputs.directory }}
-    - ${{ inputs.requirements_txt }}
-    - ${{ inputs.lambda_layer_arn }}
-    - ${{ inputs.lambda_function_name }}
 branding:
   icon: 'layers'
   color: 'yellow'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,11 @@ install_zip_dependencies(){
 	echo "Installing and zipping dependencies..."
 	mkdir python
 	pip install --target=python -r "${INPUT_REQUIREMENTS_TXT}"
+	if [ -z "${INPUT_LAMBDA_FUNCTION_NAME}" ]
+	then
+		cp -R "${INPUT_LAMBDA_DIRECTORY}"/* ./python
+		rm -rf ./python/.git*
+	fi
 	zip -r dependencies.zip ./python
 }
 
@@ -30,8 +35,7 @@ update_function_layers(){
 deploy_lambda_function(){
 	install_zip_dependencies
 	publish_dependencies_as_layer
-	publish_function_code
-	update_function_layers
+	[ ! -z "${INPUT_LAMBDA_FUNCTION_NAME}" ] && publish_function_code && update_function_layers
 }
 
 deploy_lambda_function


### PR DESCRIPTION
**Summary:**  Make the 'lambda_function_name' input parameter for github action optional. When the function name is not specified, deploy only a layer - which has the contents of the lambda directory specified and requirements.

**Details:**
This PR is about making a change to the py-lambda-action. 
When we want to create a lambda there are 2 main things we need to take care of initially:
-> Have all our code in a directory
-> Have the requirements.txt file in the directory

The steps to create a lambda in AWS involves:
-> zipping our code and uploading it to the lambda
-> install the dependencies which are required to run the lambda

We can do the above steps automatically using github actions. The py-lambda-action helps in implementing the above steps.
This action takes 4 input arguments:
lambda_layer, lamda_function_name, lambda_directory, requirements.txt 
More details about these are present in the Readme file

**Existing scenario:**
lambda_layer, requirements.txt, lamda_function_name are mandatory arguments. lambda_directory is optional

**What change I made:**
lamda_function_name optional
When we do not give a lambda function name, the code and the requirements are together created as a layer. 
So, I put a condition to check if the function name is given and accordingly created a zip file of the code and requirements.
If the lamda directory is specified, the code is taken from that directory. If not specified, the code is taken from the current working directory

I explained more details about the different workflows in a flow diagram. It is attached to this ticket.

**How to setup the code:** (Have also mentioned the steps I followed to test this change)

1. Clone the qxf2-lambdas repository. All the lambdas are maintained in this repo.
https://github.com/qxf2/qxf2-lambdas

2. Create a branch and switch to it. 
I used make_lamda_code_optional

3. Create a folder and place requirements.txt and your code in a .py file
I created one called "test_py_lambda_action". I had a python file which hits 'https://api.github.com'and gets the response.
In my requirements.txt file, I placed "requests".

4. Create a workflow in .github\workflows. The structure is present in the Readme of https://github.com/qxf2/py-lambda-action
There are also examples of other workflows present in the qxf2-lambdas repo.

5. The workflow has:
    branches: make_lamda_code_optional
    steps -
        uses: qxf2/py-lambda-action@v1.0.3
For testing purposes, I had forked the repo, made the changes and tested. So, I used sravantit25/py-lambda-action@master
I also verified the change by tagging my branch as 'test_v1.0.3'. You can use this for testing.

    with:
        lambda_directory: the folder name gave in step 3
        lambda_layer_arn: 'arn:aws:lambda:ap-south-1:285993504765:layer:<any_name>'
        requirements_txt: 'folder_name/requirements_txt'
    I did not use lambda_function_name

This workflow will get triggered whenever I push any change to mentioned branch.

6. Go to AWS console and login as 'lambda-tester' user. Credentials are present in trello. 
Navigate to Lambda - Functions page. Create a function. Just follow the basic steps.
The lambda which I created for testing is 'test_py_lambda'

7. Commit and push your code. 
Whatever code I placed in my test_py_lambda_action folder, I pushed it to 'make_lamda_code_optional' branch

So, the workflow will run, do a zip of the code and requirements_txt and create it as a layer in AWS. 
Can check the status of the workflow by going to the Actions tab  - https://github.com/qxf2/qxf2-lambdas/actions

8. Go the AWS console and navigate to Lambda -> Layers. 
A layer with version should have been created with the name you mentioned in the .yml file. 
When I was running the test, 'test-py-action-without-function' got created (ver 2 latest)
Can also download the zip and verify that the dependencies and files present in our folder are present.

9. Go to the lambda function crated in Step 3. Navigate to the Layers section and choose Add a layer. 
Choose 'Specify an ARN' option and give the complete layer name (including version)

The above step will apply the layer to our lambda. It means it has deployed our code and installed the dependencies.
PS: You might not be able to view the code

10. Test the lambda :
Click on Test and observe the output in Function logs.
In my case, I was able to see the 'Response 200' and I was able to confirm that the requests library which I had (in requirements_txt) was installed properly and the code ran.

All the above testing steps I did are present in my branch - 'make_lamda_code_optional' in qxf2-lambdas repo